### PR TITLE
[WEB-3061] Bound DynamoDB purge by cutoff

### DIFF
--- a/lib/WrappedDynamoDbClient.js
+++ b/lib/WrappedDynamoDbClient.js
@@ -470,8 +470,18 @@ export class WrappedDynamoDbClient {
           _.isString(cutoffAttribute) && cutoffAttribute.length,
       );
 
-    if (!_.isNil(cutoffAttribute) && _.isNil(cutoffValue))
-      throw new Error('cutoffValue must not be nil when cutoffAttribute is set');
+    if (!_.isNil(cutoffAttribute)) {
+      if (_.isNil(cutoffValue))
+        throw new Error('cutoffValue must not be nil when cutoffAttribute is set');
+
+      this.#validateParam(
+        'cutoffValue',
+        cutoffValue,
+        (cutoffValue) =>
+          (_.isString(cutoffValue) && cutoffValue.length > 0) ||
+          (_.isNumber(cutoffValue) && Number.isFinite(cutoffValue)),
+      );
+    }
 
     this.#validateParam(
       'includeMissingCutoff',
@@ -493,7 +503,7 @@ export class WrappedDynamoDbClient {
 
     let purged = 0;
     do {
-      var { Items: items, LastEvaluatedKey: lastEvaluatedKey } =
+      var { Items: items = [], LastEvaluatedKey: lastEvaluatedKey } =
         await this.scan(tableName, {
           ...cutoffScanOptions,
           ...(lastEvaluatedKey ? { ExclusiveStartKey: lastEvaluatedKey } : {}),
@@ -508,7 +518,7 @@ export class WrappedDynamoDbClient {
 
         this.#logger.debug(`  Purged ${purged} items.`);
       }
-    } while (items.length || lastEvaluatedKey);
+    } while (lastEvaluatedKey);
 
     this.#logger.debug(`Done.\n`);
 

--- a/lib/WrappedDynamoDbClient.js
+++ b/lib/WrappedDynamoDbClient.js
@@ -430,10 +430,17 @@ export class WrappedDynamoDbClient {
    *
    * @param {string} tableName - Table name.
    * @param {string[]} keys - Item keys.
+   * @param {object} [options] - Purge options.
+   * @param {string} [options.cutoffAttribute] - Attribute used to bound
+   * the purge to items that existed before a cutoff.
+   * @param {number|string} [options.cutoffValue] - Maximum cutoffAttribute
+   * value to purge. Defaults to Date.now() when cutoffAttribute is set.
+   * @param {boolean} [options.includeMissingCutoff] - Whether to purge
+   * items missing cutoffAttribute. Default true.
    * @return {Promise<number>} Total items purged from table.
    * @category item
    */
-  async purgeItems(tableName, keys) {
+  async purgeItems(tableName, keys, options = {}) {
     this.#validateTableName(tableName);
 
     this.#validateParam(
@@ -443,15 +450,54 @@ export class WrappedDynamoDbClient {
         _.isArray(keys) && keys.length && keys.every((key) => _.isString(key)),
     );
 
+    this.#validateParam(
+      'options',
+      options,
+      (options) => _.isPlainObject(options),
+    );
+
+    const {
+      cutoffAttribute,
+      cutoffValue = Date.now(),
+      includeMissingCutoff = true,
+    } = options;
+
+    if (!_.isNil(cutoffAttribute))
+      this.#validateParam(
+        'cutoffAttribute',
+        cutoffAttribute,
+        (cutoffAttribute) =>
+          _.isString(cutoffAttribute) && cutoffAttribute.length,
+      );
+
+    if (!_.isNil(cutoffAttribute) && _.isNil(cutoffValue))
+      throw new Error('cutoffValue must not be nil when cutoffAttribute is set');
+
+    this.#validateParam(
+      'includeMissingCutoff',
+      includeMissingCutoff,
+      (includeMissingCutoff) => _.isBoolean(includeMissingCutoff),
+    );
+
+    const cutoffScanOptions = _.isNil(cutoffAttribute)
+      ? {}
+      : {
+          ExpressionAttributeNames: { '#cutoff': cutoffAttribute },
+          ExpressionAttributeValues: { ':cutoff': cutoffValue },
+          FilterExpression: includeMissingCutoff
+            ? '(attribute_not_exists(#cutoff) OR #cutoff <= :cutoff)'
+            : '#cutoff <= :cutoff',
+        };
+
     this.#logger.debug(`Purging DynamoDB table '${tableName}'...`);
 
     let purged = 0;
     do {
       var { Items: items, LastEvaluatedKey: lastEvaluatedKey } =
-        await this.scan(
-          tableName,
-          lastEvaluatedKey ? { ExclusiveStartKey: lastEvaluatedKey } : {},
-        );
+        await this.scan(tableName, {
+          ...cutoffScanOptions,
+          ...(lastEvaluatedKey ? { ExclusiveStartKey: lastEvaluatedKey } : {}),
+        });
 
       if (items.length) {
         const itemKeys = items.map((item) => _.pick(item, keys));
@@ -462,7 +508,7 @@ export class WrappedDynamoDbClient {
 
         this.#logger.debug(`  Purged ${purged} items.`);
       }
-    } while (items.length);
+    } while (items.length || lastEvaluatedKey);
 
     this.#logger.debug(`Done.\n`);
 
@@ -636,7 +682,7 @@ export class WrappedDynamoDbClient {
    * @param {string} tableName - Table name.
    * @param {object[]} items - Array of item objects.
    * @param {object[]|object} [conditionExpressions] - Array of condition expressions for each item or a single condition expression.
-   * @param {boolean} [applyConditionExpressionsToAllItems=false] - If true, apply the same condition expression to all items. Default false.
+   * @param {boolean} [applyConditionExpressionsToAllItems] - If true, apply the same condition expression to all items. Default false.
    * @param {Function} [getExpressionCb] - Callback function to find the condition expression for each item.
    * @return {Promise<Array>} Array of responses from chunked batchWrite operations.
    * @description Complex condition expressions, ExpressionAttributeNames, and ExpressionAttributeValues are not yet supported.

--- a/lib/WrappedDynamoDbClient.test.js
+++ b/lib/WrappedDynamoDbClient.test.js
@@ -52,7 +52,6 @@ describe('WrappedDynamoDbClient', function () {
           Items: [{ entityPK: 'old', entitySK: 0, created: 1 }],
           LastEvaluatedKey: undefined,
         },
-        { Items: [], LastEvaluatedKey: undefined },
       ];
 
       client.scan = async (tableName, options) => {
@@ -71,7 +70,7 @@ describe('WrappedDynamoDbClient', function () {
       });
 
       expect(purged).to.equal(1);
-      expect(scans).to.have.length(3);
+      expect(scans).to.have.length(2);
       expect(scans[0].options).to.include({
         FilterExpression: '(attribute_not_exists(#cutoff) OR #cutoff <= :cutoff)',
       });
@@ -88,6 +87,44 @@ describe('WrappedDynamoDbClient', function () {
       expect(deletes).to.deep.equal([
         { tableName: 'table', keys: [{ entityPK: 'old', entitySK: 0 }] },
       ]);
+    });
+
+    it('should handle scan pages with omitted Items', async function () {
+      const client = new WrappedDynamoDbClient();
+      const scans = [];
+
+      client.scan = async (tableName, options) => {
+        scans.push({ tableName, options });
+        return {};
+      };
+
+      client.deleteItems = async () => {
+        throw new Error('deleteItems should not be called');
+      };
+
+      const purged = await client.purgeItems('table', ['entityPK', 'entitySK']);
+
+      expect(purged).to.equal(0);
+      expect(scans).to.have.length(1);
+    });
+
+    it('should reject invalid cutoff values', async function () {
+      const client = new WrappedDynamoDbClient();
+
+      for (const cutoffValue of ['', NaN, {}, []]) {
+        let error;
+
+        try {
+          await client.purgeItems('table', ['entityPK', 'entitySK'], {
+            cutoffAttribute: 'created',
+            cutoffValue,
+          });
+        } catch (err) {
+          error = err;
+        }
+
+        expect(error).to.be.an.instanceof(Error);
+      }
     });
   });
 

--- a/lib/WrappedDynamoDbClient.test.js
+++ b/lib/WrappedDynamoDbClient.test.js
@@ -41,6 +41,56 @@ describe('WrappedDynamoDbClient', function () {
     });
   });
 
+  describe('purgeItems', function () {
+    it('should bound purges by cutoff and continue filtered pagination', async function () {
+      const client = new WrappedDynamoDbClient();
+      const scans = [];
+      const deletes = [];
+      const pages = [
+        { Items: [], LastEvaluatedKey: { entityPK: 'a', entitySK: 1 } },
+        {
+          Items: [{ entityPK: 'old', entitySK: 0, created: 1 }],
+          LastEvaluatedKey: undefined,
+        },
+        { Items: [], LastEvaluatedKey: undefined },
+      ];
+
+      client.scan = async (tableName, options) => {
+        scans.push({ tableName, options });
+        return pages.shift();
+      };
+
+      client.deleteItems = async (tableName, keys) => {
+        deletes.push({ tableName, keys });
+        return [];
+      };
+
+      const purged = await client.purgeItems('table', ['entityPK', 'entitySK'], {
+        cutoffAttribute: 'created',
+        cutoffValue: 2,
+      });
+
+      expect(purged).to.equal(1);
+      expect(scans).to.have.length(3);
+      expect(scans[0].options).to.include({
+        FilterExpression: '(attribute_not_exists(#cutoff) OR #cutoff <= :cutoff)',
+      });
+      expect(scans[0].options.ExpressionAttributeNames).to.deep.equal({
+        '#cutoff': 'created',
+      });
+      expect(scans[0].options.ExpressionAttributeValues).to.deep.equal({
+        ':cutoff': 2,
+      });
+      expect(scans[1].options.ExclusiveStartKey).to.deep.equal({
+        entityPK: 'a',
+        entitySK: 1,
+      });
+      expect(deletes).to.deep.equal([
+        { tableName: 'table', keys: [{ entityPK: 'old', entitySK: 0 }] },
+      ]);
+    });
+  });
+
   describe('tables', function () {
     describe('validations', function () {
       it('create/delete should close', async function () {
@@ -158,6 +208,45 @@ describe('WrappedDynamoDbClient', function () {
               ExpressionAttributeValues: { ':PK': entityPK },
             });
             expect(response.Items).to.be.empty;
+          });
+
+          it('purge with cutoff should preserve newer items', async function () {
+            const entityPK = nanoid();
+            const cutoffValue = Date.now();
+            const oldItem = { entityPK, entitySK: 0, created: cutoffValue - 1 };
+            const missingCutoffItem = { entityPK, entitySK: 1 };
+            const newItem = { entityPK, entitySK: 2, created: cutoffValue + 1 };
+
+            // Put items.
+            let response = await baseClient.putItems(tableName, [
+              oldItem,
+              missingCutoffItem,
+              newItem,
+            ]);
+            expect(_.every(response, (r) => r.$metadata.httpStatusCode === 200))
+              .to.be.true;
+
+            // Purge items at cutoff.
+            const purged = await baseClient.purgeItems(
+              tableName,
+              ['entityPK', 'entitySK'],
+              { cutoffAttribute: 'created', cutoffValue },
+            );
+            expect(purged).to.equal(2);
+
+            // Query items.
+            response = await baseClient.query(tableName, {
+              KeyConditionExpression: '#PK = :PK',
+              ExpressionAttributeNames: { '#PK': 'entityPK' },
+              ExpressionAttributeValues: { ':PK': entityPK },
+            });
+            expect(response.Items.map(({ entitySK }) => entitySK)).to.deep.equal(
+              [2],
+            );
+
+            // Delete remaining item.
+            response = await baseClient.deleteItem(tableName, newItem);
+            expect(response.$metadata.httpStatusCode).to.equal(200);
           });
 
           it('transactPuts/transactDeletes should close', async function () {


### PR DESCRIPTION
## Summary

- add optional cutoff-bounded purge support to `WrappedDynamoDbClient.purgeItems`
- preserve records newer than the caller-provided cutoff during scan/delete purges
- continue filtered scans while `LastEvaluatedKey` exists, even when the filtered page has no `Items`
- add regression coverage for cutoff filter construction and filtered pagination

## Context

This addresses the reset race found in Texas: ledger metric accounts were created during reset and then deleted by the ongoing ledger purge because the purge scanned a live table without a boundary. Callers can now capture a purge-start cutoff and pass it to `purgeItems` so later-created records are not included in the purge set.

Expected follow-up in `aws-service`: call `purgeItems(tableName, keys, { cutoffAttribute: 'created', cutoffValue: purgeStartedAt })` from `purgeEndpointHandler`.

## Verification

- `npm run lint` ✅
- `npx mocha --grep "bound purges"` ✅
- `npm run build` ✅ completed; emitted existing Browserslist/Babel deprecation warnings
- `npm test` ⚠️ blocked locally: `vc aws -c "mocha"` reaches AWS as `arn:aws:iam::546652796775:user/jeeves`, but that user lacks `dynamodb:CreateTable` / `dynamodb:DeleteTable`, which the existing integration suite requires
- `npx ncu --peer` ⚠️ reviewed; many major updates available, plus `@veterancrowd/aws-cli` auth failure. No dependency changes applied in this hotfix.
