### PR TITLE
[WEB-3061] Fix cutoff purge cleanup key

### DIFF
--- a/lib/WrappedDynamoDbClient.test.js
+++ b/lib/WrappedDynamoDbClient.test.js
@@ -282,7 +282,10 @@ describe('WrappedDynamoDbClient', function () {
             );
 
             // Delete remaining item.
-            response = await baseClient.deleteItem(tableName, newItem);
+            response = await baseClient.deleteItem(
+              tableName,
+              _.pick(newItem, ['entityPK', 'entitySK']),
+            );
             expect(response.$metadata.httpStatusCode).to.equal(200);
           });
 


### PR DESCRIPTION
## Summary

- Fixes the cutoff purge integration test cleanup to delete the remaining item by table key only.
- Prevents DynamoDB `ValidationException: The provided key element does not match the schema` when the remaining item contains non-key attributes like `created`.

## Verification

- `npm run lint`
- `npm run build`
- Targeted live test could not complete locally because AWS credentials are unavailable in this runtime.
