### PR TITLE
[WEB-3061] Support full transact put condition objects

### DIFF
--- a/lib/WrappedDynamoDbClient.js
+++ b/lib/WrappedDynamoDbClient.js
@@ -694,7 +694,7 @@ export class WrappedDynamoDbClient {
    * @param {object[]|object} [conditionExpressions] - Array of condition expressions for each item or a single condition expression.
    * @param {boolean} [applyConditionExpressionsToAllItems] - If true, apply the same condition expression to all items. Default false.
    * @param {Function} [getExpressionCb] - Callback function to find the condition expression for each item.
-   * @return {Promise<Array>} Array of responses from chunked batchWrite operations.
+   * @return {Promise<object>} DynamoDB TransactWriteCommand output.
    * @description Condition objects support `expression`, `ExpressionAttributeNames`, and `ExpressionAttributeValues`.
    * @category item
    */

--- a/lib/WrappedDynamoDbClient.js
+++ b/lib/WrappedDynamoDbClient.js
@@ -695,7 +695,7 @@ export class WrappedDynamoDbClient {
    * @param {boolean} [applyConditionExpressionsToAllItems] - If true, apply the same condition expression to all items. Default false.
    * @param {Function} [getExpressionCb] - Callback function to find the condition expression for each item.
    * @return {Promise<Array>} Array of responses from chunked batchWrite operations.
-   * @description Complex condition expressions, ExpressionAttributeNames, and ExpressionAttributeValues are not yet supported.
+   * @description Condition objects support `expression`, `ExpressionAttributeNames`, and `ExpressionAttributeValues`.
    * @category item
    */
   async transactPutItems(
@@ -734,7 +734,11 @@ export class WrappedDynamoDbClient {
 
     const result = await this.#doc.transactWrite({
       TransactItems: items.map((item) => {
-        const { expression } = applyConditionExpressionsToAllItems
+        const {
+          expression,
+          ExpressionAttributeNames,
+          ExpressionAttributeValues,
+        } = applyConditionExpressionsToAllItems
           ? (conditionExpressions ?? {})
           : (getExpressionCb(item) ?? {});
 
@@ -743,6 +747,8 @@ export class WrappedDynamoDbClient {
             Item: item,
             TableName: tableName,
             ConditionExpression: expression ?? undefined,
+            ExpressionAttributeNames,
+            ExpressionAttributeValues,
           },
         };
       }),

--- a/lib/WrappedDynamoDbClient.test.js
+++ b/lib/WrappedDynamoDbClient.test.js
@@ -364,6 +364,52 @@ describe('WrappedDynamoDbClient', function () {
               }
             }
           });
+
+          it('transactPuts should support expression attribute names and values', async function () {
+            const entityPK = nanoid();
+            const item = { entityPK, entitySK: 0, version: 1 };
+            const updatedItem = { ...item, version: 2 };
+
+            await baseClient.putItem(tableName, item);
+
+            const response = await baseClient.transactPutItems(
+              tableName,
+              [updatedItem],
+              [
+                {
+                  entityPK,
+                  entitySK: item.entitySK,
+                  expression: '#version = :expectedVersion',
+                  ExpressionAttributeNames: { '#version': 'version' },
+                  ExpressionAttributeValues: { ':expectedVersion': 1 },
+                },
+              ],
+            );
+            expect(response.$metadata.httpStatusCode).to.equal(200);
+
+            try {
+              await baseClient.transactPutItems(
+                tableName,
+                [{ ...item, version: 3 }],
+                [
+                  {
+                    entityPK,
+                    entitySK: item.entitySK,
+                    expression: '#version = :expectedVersion',
+                    ExpressionAttributeNames: { '#version': 'version' },
+                    ExpressionAttributeValues: { ':expectedVersion': 1 },
+                  },
+                ],
+              );
+
+              expect.fail('Expected TransactionCanceledException to be thrown.');
+            } catch (error) {
+              expect(error).to.be.an.instanceof(TransactionCanceledException);
+              expect(error.CancellationReasons[0].Code).to.equal(
+                'ConditionalCheckFailed',
+              );
+            }
+          });
         });
 
         describe('put ... delete', function () {


### PR DESCRIPTION
## Summary
- extend `transactPutItems` condition objects to pass `ExpressionAttributeNames`
- extend `transactPutItems` condition objects to pass `ExpressionAttributeValues`
- keep existing `expression`-only behavior backward-compatible
- add a regression covering placeholder names/values and stale conditional failure

## Why
`api-ledger` needs optimistic concurrency around account `lastEntry` sequencing. That requires a transaction condition like `#seq = :expectedSeq`, which cannot work unless the wrapper passes the corresponding expression names/values to DynamoDB.

## Verification
- `npm run lint` ✅
- `npm run build` ✅ (existing Browserslist/Babel deprecation warnings)
- `npm test` ⚠️ blocked by IAM: `arn:aws:iam::537756955768:user/jeeves` lacks `dynamodb:CreateTable`/`DeleteTable` for the existing integration suite. The non-AWS purge tests ran before the permissions failure.
- `npx ncu --peer` reviewed; dependency drift only, no dependency changes applied
